### PR TITLE
Fix event creation/deletion bugs

### DIFF
--- a/app/assets/stylesheets/base/elements/form.scss
+++ b/app/assets/stylesheets/base/elements/form.scss
@@ -37,6 +37,7 @@ textarea {
   font-size: 1.1rem;
   transition: all 0.25s ease-in-out;
   border: $color-fg solid 1px;
+  border-radius: $border-radius;
   outline: none;
   padding: 0.25rem;
   position: relative;
@@ -62,6 +63,7 @@ textarea {
   width: 100%;
   min-height: 5rem;
   border: $color-fg solid 1px;
+  border-radius: $border-radius;
 
   &.edited {
     border-color: $edited-fg;
@@ -75,6 +77,7 @@ textarea {
 
 .input-group {
   border: $color-fg solid 1px;
+  border-radius: $border-radius;
   display: flex;
   flex-direction: row;
 

--- a/client/app/bundles/AdminView/components/EventPage/EventPageView/DeleteEvent.jsx
+++ b/client/app/bundles/AdminView/components/EventPage/EventPageView/DeleteEvent.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import * as Icon from "react-feather";
+import { Flash } from "libs/components";
 import {
   fetchCompetition,
   deleteCompetition,
@@ -11,7 +12,7 @@ class DeleteEvent extends Component {
   static propTypes = {
     eventName: PropTypes.string,
     isDeleting: PropTypes.bool,
-    // error: PropTypes.string,
+    error: PropTypes.string,
     deleteCompetition: PropTypes.func,
     fetchCompetition: PropTypes.func,
   };
@@ -51,6 +52,9 @@ class DeleteEvent extends Component {
     return (
       <div className="splitview-pane">
         <h1>Delete Event</h1>
+        <Flash type="alert" when={this.props.error.length > 0}>
+          {this.props.error}
+        </Flash>
         <p>
           This will delete the current event, along with any attendee details,
           all timeline data and any other associated data and files. This

--- a/client/app/bundles/AdminView/components/EventPage/EventPageView/DeleteEvent.jsx
+++ b/client/app/bundles/AdminView/components/EventPage/EventPageView/DeleteEvent.jsx
@@ -2,7 +2,10 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import * as Icon from "react-feather";
-import { deleteCompetition } from "libs/actions/competitionActions";
+import {
+  fetchCompetition,
+  deleteCompetition,
+} from "libs/actions/competitionActions";
 
 class DeleteEvent extends Component {
   static propTypes = {
@@ -10,6 +13,7 @@ class DeleteEvent extends Component {
     isDeleting: PropTypes.bool,
     // error: PropTypes.string,
     deleteCompetition: PropTypes.func,
+    fetchCompetition: PropTypes.func,
   };
 
   static defaultProps = {
@@ -17,6 +21,7 @@ class DeleteEvent extends Component {
     isDeleting: false,
     error: "",
     deleteCompetition: () => {},
+    fetchCompetition: () => {},
   };
 
   constructor(props) {
@@ -25,6 +30,13 @@ class DeleteEvent extends Component {
       eventInputValue: "",
       canDelete: false,
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // if deleted event
+    if (this.props.isDeleting && !nextProps.isDeleting) {
+      this.props.fetchCompetition();
+    }
   }
 
   onChangeEventName(e) {
@@ -80,6 +92,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  fetchCompetition: () => dispatch(fetchCompetition()),
   deleteCompetition: () => dispatch(deleteCompetition()),
 });
 

--- a/client/app/bundles/AdminView/components/EventPage/index.jsx
+++ b/client/app/bundles/AdminView/components/EventPage/index.jsx
@@ -35,7 +35,7 @@ class EventPage extends Component {
           (not including if competition doesn't yet exist)
         */}
         {this.props.error &&
-          this.props.error !== "404 Not Found" && (
+          !this.props.error.includes("404") && (
             <div className="alert">
               <strong>Error:</strong> {this.props.error}
             </div>

--- a/client/app/bundles/AdminView/components/EventPage/index.jsx
+++ b/client/app/bundles/AdminView/components/EventPage/index.jsx
@@ -5,6 +5,7 @@ import {
   fetchCompetition,
   saveCompetition,
 } from "libs/actions/competitionActions";
+import { Flash } from "libs/components";
 
 import EventPageView from "./EventPageView";
 import CreateEvent from "./CreateEvent";
@@ -14,18 +15,39 @@ class EventPage extends Component {
     getCompetition: PropTypes.func.isRequired,
     saveCompetition: PropTypes.func.isRequired,
     isSaving: PropTypes.bool,
+    isDeleting: PropTypes.bool,
     error: PropTypes.string,
     competitionExists: PropTypes.bool,
   };
 
   static defaultProps = {
     isSaving: false,
+    isDeleting: false,
     error: "",
     competitionExists: true,
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      deleteSuccess: false,
+    };
+  }
+
   componentDidMount() {
     this.props.getCompetition();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // set success to true if we just deleted an event
+    if (this.props.isDeleting && !nextProps.isDeleting && !nextProps.error) {
+      this.setState({ deleteSuccess: true });
+    }
+
+    // we just created an event
+    if (this.props.isSaving && !nextProps.isSaving && !nextProps.error) {
+      this.setState({ deleteSuccess: false });
+    }
   }
 
   render() {
@@ -34,18 +56,24 @@ class EventPage extends Component {
         {/* Show alert if there's an error fetching competition
           (not including if competition doesn't yet exist)
         */}
-        {this.props.error &&
-          !this.props.error.includes("404") && (
-            <div className="alert">
-              <strong>Error:</strong> {this.props.error}
-            </div>
-          )}
+        <Flash
+          type="alert"
+          when={
+            this.props.error.length > 0 && !this.props.error.includes("404")
+          }
+        >
+          <strong>Error:</strong> {this.props.error}
+        </Flash>
+
+        <Flash type="success" when={this.state.deleteSuccess}>
+          Event successfully deleted!
+        </Flash>
 
         {this.props.competitionExists ? (
           <EventPageView />
         ) : (
           <div>
-            <h2>Create New Event</h2>
+            <h1>Create New Event</h1>
             <CreateEvent
               onClickSave={this.props.saveCompetition}
               isSaving={this.props.isSaving}
@@ -60,6 +88,7 @@ class EventPage extends Component {
 const mapStateToProps = state => ({
   error: state.competition.error,
   competitionExists: state.competition.competitionExists,
+  isDeleting: state.competition.isDeleting,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/client/app/libs/actions/competitionActions/index.js
+++ b/client/app/libs/actions/competitionActions/index.js
@@ -106,7 +106,8 @@ export const deleteCompetition = () => async dispatch => {
   dispatch(setIsDeletingCompetition());
   try {
     await jsonDeleteRequest(constants.COMPETITION_PATH);
-    return dispatch(deleteCompetitionSuccess());
+    await dispatch(deleteCompetitionSuccess());
+    return dispatch(fetchCompetition());
   } catch (error) {
     return dispatch(
       deleteCompetitionFailure(

--- a/client/app/libs/reducers/competitionReducer/index.js
+++ b/client/app/libs/reducers/competitionReducer/index.js
@@ -40,7 +40,7 @@ export default (state = initialState, action = null) => {
       return {
         ...state,
         isFetching: false,
-        competitionExists: false,
+        competitionExists: !error.includes("404"),
         error,
       };
     }

--- a/client/app/libs/utils/Requests.js
+++ b/client/app/libs/utils/Requests.js
@@ -113,8 +113,8 @@ export const jsonPostRequest = async (path, body, headers = {}) => {
  * @param  {Object}  [headers={}] Additional headers to add to request
  * @return {Promise}              Promise that contains JSON response if successful
  */
-export const jsonDeleteRequest = async (path, headers = {}) =>
-  fetch(path, {
+export const jsonDeleteRequest = async (path, headers = {}) => {
+  const res = await fetch(path, {
     method: "DELETE",
     headers: {
       Accept: "application/json",
@@ -125,10 +125,16 @@ export const jsonDeleteRequest = async (path, headers = {}) =>
       authenticity_token: getMetaContent("csrf-token"),
     }),
     credentials: "include",
-  }).then(
-    res =>
-      res.ok ? res.json() : Promise.reject(`${res.status} ${res.statusText}`),
-  );
+  });
+  const json = res.status === 204 ? "" : await res.json();
+  if (res.ok) {
+    return json;
+  }
+  if (json.message) {
+    throw new Error(`${res.status}: ${json.message}`);
+  }
+  throw new Error(`${res.status} ${res.statusText}`);
+};
 
 export default {
   getMetaContent,


### PR DESCRIPTION
* Fix bug with jsonDeleteRequest failing on empty response body that caused event deletion to fail silently
* Add feedback flashes when deleting events, for both success and failures
* Make event page refresh on event creation
* Hide 404 error from event creation page
* Fixes issue #29